### PR TITLE
Minor fix for more recent three js versions.

### DIFF
--- a/src/MeshReflectorMaterial.js
+++ b/src/MeshReflectorMaterial.js
@@ -82,7 +82,6 @@ export default class MeshReflectorMaterial extends MeshStandardMaterial {
     fbo1.depthBuffer = true
     fbo1.depthTexture = new DepthTexture(resolution, resolution)
     fbo1.depthTexture.format = DepthFormat
-    fbo1.depthTexture.type = UnsignedShortType
 
     const fbo2 = new WebGLRenderTarget(resolution, resolution, parameters)
 


### PR DESCRIPTION
When using the MeshReflectorMaterial as a mirror in recent three js versions, it appears black. If I understand it correctly this happens since r141 (https://github.com/mrdoob/three.js/wiki/Migration-Guide#140--141), _"The default type of DepthTexture is now UnsignedIntType."_.

This is fixed by deleting a line in MeshReflectorMaterial.js.

Tested on aframe 1.6 (three r164).